### PR TITLE
Feature/todo 13 git hook branch naming

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+REGEX="^(develop|master|release|((feature|bigfeature|task|bugfix|hotfix)\/[a-zA-Z]+-[0-9]+_.+))$"
+
+if ! [[ $BRANCH =~ $REGEX ]]; then
+  echo "Your commit was rejected due to branching name"
+  echo "Please rename your branch with $REGEX syntax"
+  exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -37,12 +37,6 @@ Branches should be identified as feature|task|bugfix|hotfix, followed by the JIR
 feature/PIDEV-54_enforce_branch_naming_conventions
 ```
 
-There is a committed .git-hooks folder containing a hook that enforces this rule. Please run the following command before you start making commits to this repo:
-
-```
-git config core.hooksPath .git-hooks
-```
-
 ## Project Workflow
 
 project management strategies

--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ performance and accessibility audit
 how the project can be cloned and run
 how to use the application
 
+### Branch naming conventions
+
+Branches should be identified as feature|task|bugfix|hotfix, followed by the JIRA task id and a description, for example:
+
+```
+feature/PIDEV-54_enforce_branch_naming_conventions
+```
+
+There is a committed .git-hooks folder containing a hook that enforces this rule. Please run the following command before you start making commits to this repo:
+
+```
+git config core.hooksPath .git-hooks
+```
+
 ## Project Workflow
 
 project management strategies


### PR DESCRIPTION
- New git hook added to enforce branch naming conventions
- An example of the new convention is `feature/TODO-13_git_hook_branch_naming`
- This enforces consistency across the repository